### PR TITLE
Geometry groups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/*.rs.bk
 Cargo.lock
 *.obj
+.vscode/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "obj-exporter"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Adam Rzepka <adam@simteract.com>"]
 description = "Wavefront obj exporter for Rust"
 repository = "https://github.com/Simteract/obj-exporter-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ travis-ci = { repository = "Simteract/obj-exporter-rs", branch = "master" }
 
 [dependencies]
 wavefront_obj = "5.1.0"
-itertools = "0.6.1"
+lazy_static = "1.0"

--- a/examples/export_obj_multiple.rs
+++ b/examples/export_obj_multiple.rs
@@ -1,86 +1,65 @@
 extern crate obj_exporter as obj;
 
-use std::path::Path;
-use obj::{ObjSet, Object, Vertex, Geometry, Shape, Primitive};
+use obj::{Geometry, ObjSet, Object, Primitive, Shape, Vertex};
 
 pub fn main() {
   let set = ObjSet {
-      material_library: None,
-      objects: vec![
-        Object {
-          name: "Square1".to_owned(),
-          vertices: vec![
-            (-1, -1, 0),
-            (1, -1, 0),
-            (1, 1, 0),
-            (-1, 1, 0)
-          ].into_iter().map(|(x, y, z)| {
-            Vertex {
-              x: x as f64,
-              y: y as f64,
-              z: z as f64,
-            }
-          }).collect(),
-          tex_vertices: vec![],
-          normals: vec![],
-          geometry: vec![
-            Geometry {
-              material_name: None,
-              shapes: vec![
-                (0, 1, 2),
-                (0, 2, 3)
-              ].into_iter().map(|(x, y, z)| {
-                Shape {
-                  primitive: Primitive::Triangle(
-                    (x, None, None),
-                    (y, None, None),
-                    (z, None, None)
-                  ),
-                  groups: vec![],
-                  smoothing_groups: vec![],
-                }
-              }).collect(),
-            }
-          ],
-        },
-        Object {
-          name: "Square2".to_owned(),
-          vertices: vec![
-            (1, -1, 0),
-            (2, -1, 0),
-            (2, 1, 0),
-            (1, 1, 0)
-          ].into_iter().map(|(x, y, z)| {
-            Vertex {
-              x: x as f64,
-              y: y as f64,
-              z: z as f64,
-            }
-          }).collect(),
-          tex_vertices: vec![],
-          normals: vec![],
-          geometry: vec![
-            Geometry {
-              material_name: None,
-              shapes: vec![
-                (0, 1, 2),
-                (0, 2, 3)
-              ].into_iter().map(|(x, y, z)| {
-                Shape {
-                  primitive: Primitive::Triangle(
-                    (x, None, None),
-                    (y, None, None),
-                    (z, None, None)
-                  ),
-                  groups: vec![],
-                  smoothing_groups: vec![],
-                }
-              }).collect(),
-            }
-          ],
-        }
-      ],
-    };
+    material_library: None,
+    objects: vec![
+      Object {
+        name: "Square1".to_owned(),
+        vertices: vec![
+          (-1.0, -1.0, 0.0),
+          (1.0, -1.0, 0.0),
+          (1.0, 1.0, 0.0),
+          (-1.0, 1.0, 0.0),
+        ].into_iter()
+          .map(|(x, y, z)| Vertex { x, y, z })
+          .collect(),
+        tex_vertices: vec![],
+        normals: vec![],
+        geometry: vec![
+          Geometry {
+            material_name: None,
+            shapes: vec![(0, 1, 2), (0, 2, 3)]
+              .into_iter()
+              .map(|(x, y, z)| Shape {
+                primitive: Primitive::Triangle((x, None, None), (y, None, None), (z, None, None)),
+                groups: vec![],
+                smoothing_groups: vec![],
+              })
+              .collect(),
+          },
+        ],
+      },
+      Object {
+        name: "Square2".to_owned(),
+        vertices: vec![
+          (1.0, -1.0, 0.0),
+          (2.0, -1.0, 0.0),
+          (2.0, 1.0, 0.0),
+          (1.0, 1.0, 0.0),
+        ].into_iter()
+          .map(|(x, y, z)| Vertex { x, y, z })
+          .collect(),
+        tex_vertices: vec![],
+        normals: vec![],
+        geometry: vec![
+          Geometry {
+            material_name: None,
+            shapes: vec![(0, 1, 2), (0, 2, 3)]
+              .into_iter()
+              .map(|(x, y, z)| Shape {
+                primitive: Primitive::Triangle((x, None, None), (y, None, None), (z, None, None)),
+                groups: vec![],
+                smoothing_groups: vec![],
+              })
+              .collect(),
+          },
+        ],
+      },
+    ],
+  };
 
-    obj::export_to_file(&set, Path::new("output_multiple.obj")).unwrap();
+  obj::export_to_file(&set, "output_multiple.obj").unwrap();
 }

--- a/examples/export_obj_single.rs
+++ b/examples/export_obj_single.rs
@@ -1,69 +1,52 @@
 extern crate obj_exporter as obj;
 
-use std::path::Path;
-use obj::{ObjSet, Object, Vertex, TVertex, Geometry, Shape, Primitive};
+use obj::{Geometry, ObjSet, Object, Primitive, Shape, TVertex, Vertex};
 
 pub fn main() {
-    let set = ObjSet {
-        material_library: None,
-        objects: vec![
-        Object {
-          name: "Square".to_owned(),
-          vertices:
-            vec![(-1, -1,  0),
-                 (1, -1, 0),
-                 (1, 1, 0),
-                 (-1, 1,  0)]
-            .into_iter()
-            .map(|(x, y, z)|
-              Vertex {
-                x: x as f64,
-                y: y as f64,
-                z: z as f64
+  let set = ObjSet {
+    material_library: None,
+    objects: vec![
+      Object {
+        name: "Square".to_owned(),
+        vertices: vec![
+          (-1.0, -1.0, 0.0),
+          (1.0, -1.0, 0.0),
+          (1.0, 1.0, 0.0),
+          (-1.0, 1.0, 0.0),
+        ].into_iter()
+          .map(|(x, y, z)| Vertex { x, y, z })
+          .collect(),
+        tex_vertices: vec![(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0)]
+          .into_iter()
+          .map(|(u, v)| TVertex { u, v, w: 0.0 })
+          .collect(),
+        normals: vec![
+          Vertex {
+            x: 0.0,
+            y: 0.0,
+            z: -1.0,
+          },
+        ],
+        geometry: vec![
+          Geometry {
+            material_name: None,
+            shapes: vec![(0, 1, 2), (0, 2, 3)]
+              .into_iter()
+              .map(|(x, y, z)| Shape {
+                primitive: Primitive::Triangle(
+                  (x, Some(x), Some(0)),
+                  (y, Some(y), Some(0)),
+                  (z, Some(z), Some(0)),
+                ),
+                groups: vec![],
+                smoothing_groups: vec![],
               })
-            .collect(),
-          tex_vertices: vec![
-            (0, 0),
-            (1, 0),
-            (1, 1),
-            (0, 1),
-          ].into_iter().map(|(u, v)|
-            TVertex {
-              u: u as f64,
-              v: v as f64,
-              w: 0.0,
-            }
-          ).collect(),
-          normals: vec![
-            Vertex {
-              x: 0.0,
-              y: 0.0,
-              z: -1.0,
-            }
-          ],
-          geometry: vec!(
-            Geometry {
-              material_name: None,
-              shapes:
-                vec![(0, 1, 2),
-                     (0, 2, 3)]
-                .into_iter()
-                .map(|(x, y, z)|
-                  Shape {
-                    primitive:
-                      Primitive::Triangle(
-                        (x, Some(x), Some(0)),
-                        (y, Some(y), Some(0)),
-                        (z, Some(z), Some(0))),
-                    groups: vec!(),
-                    smoothing_groups: vec!(),
-                  })
-                .collect()
-            }
-          )
-        }
-      ],
-    };
+              .collect(),
+          },
+        ],
+      },
+    ],
+  };
 
-    obj::export_to_file(&set, Path::new("output_single.obj")).unwrap();
+  obj::export_to_file(&set, "output_single.obj").unwrap();
 }

--- a/readme.md
+++ b/readme.md
@@ -9,9 +9,9 @@ Uses data types from [wavefront_obj](https://github.com/PistonDevelopers/wavefro
 - Vertices, UVs, normals
 - Points, lines, triangles
 - Many objects in file
+- Geometry groups
+- Smoothing groups
 
 ## Unsupported for now (feel free to contribute)
 - Materials
-- Geometry groups
-- Smoothing groups
 - Curves

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,86 +1,135 @@
-extern crate wavefront_obj;
 extern crate itertools;
+extern crate wavefront_obj;
 
 use std::path::Path;
-use std::io;
-use std::io::Write;
+use std::io::{BufWriter, Result, Write};
 use std::fs;
-use itertools::Itertools;
 
 use wavefront_obj::obj;
-pub use obj::{ObjSet, Object, Shape, Geometry, TVertex, Vertex, Primitive, VertexIndex, TextureIndex, NormalIndex, VTNIndex};
+pub use obj::{Geometry, GroupName, NormalIndex, ObjSet, Object, Primitive, Shape, TVertex,
+              TextureIndex, VTNIndex, Vertex, VertexIndex};
 
-/// Exports ObjSet to String.
-/// Exactly one Geometry is supported for now.
-pub fn export(obj_set: &ObjSet) -> String {
-    let mut exporter = Exporter::new();
-    exporter.export(obj_set)
+/// Exports `ObjSet` to given output.
+pub fn export<W: Write>(obj_set: &ObjSet, output: &mut W) -> Result<()> {
+    Exporter::new(output).export(obj_set)
 }
 
-/// Exports ObjSet to String and writes it to file.
-pub fn export_to_file(obj_set: &ObjSet, path: &Path) -> Result<(), io::Error> {
-    let mut file = fs::File::create(path)?;
-    let content = export(obj_set);
-    file.write(content.as_bytes())?;
-    Ok(())
+/// Exports `ObjSet`to file.
+pub fn export_to_file<P: AsRef<Path>>(obj_set: &ObjSet, path: P) -> Result<()> {
+    let file = fs::File::create(path)?;
+    let mut buffered = BufWriter::new(file);
+    export(obj_set, &mut buffered)
 }
 
-struct Exporter {
-    pub v_base_id: usize,
-    pub uv_base_id: usize,
-    pub n_base_id: usize,
+struct Exporter<'a, W: 'a + Write> {
+    output: &'a mut W,
+    v_base_id: usize,
+    uv_base_id: usize,
+    n_base_id: usize,
 }
 
-impl Exporter {
-    fn new() -> Exporter {
+impl<'a, W: 'a + Write> Exporter<'a, W> {
+    fn new(output: &'a mut W) -> Exporter<W> {
         Exporter {
+            output,
             v_base_id: 1,
             uv_base_id: 1,
             n_base_id: 1,
         }
     }
 
-    fn export(&mut self, obj_set: &ObjSet) -> String {
-        obj_set.objects.iter().map(|o| self.serialize_object(o)).join("")
+    fn export(&mut self, obj_set: &ObjSet) -> Result<()> {
+        for object in &obj_set.objects {
+            self.serialize_object(object)?;
+        }
+        Ok(())
     }
 
-    fn serialize_object(&mut self, object: &Object) -> String {
-        let name = format!("o {}\n", object.name);
-        let vertices = object.vertices.iter().map(|v| Exporter::serialize_vertex(v, "v")).join("");
-        let uvs = object.tex_vertices.iter().map(Exporter::serialize_uv).join("");
-        let normals = object.normals.iter().map(|n| Exporter::serialize_vertex(n, "vn")).join("");
-        assert_eq!(object.geometry.len(), 1);
-        let faces = object.geometry[0].shapes.iter().map(|s| self.serialize_shape(s)).join("");
+    fn serialize_object(&mut self, object: &Object) -> Result<()> {
+        write!(self.output, "o {}\n", object.name)?;
+        self.serialize_vertex_data(object)?;
+        for g in &object.geometry {
+            self.serialize_geometry(g)?;
+        }
         self.update_base_indices(object);
-        format!("{}{}{}{}{}", name, vertices, uvs, normals, faces)
+        Ok(())
     }
 
-    fn serialize_vertex(v: &Vertex, prefix: &str) -> String {
-        format!("{} {:.6} {:.6} {:.6}\n", prefix, v.x, v.y, v.z)
+    fn serialize_vertex_data(&mut self, object: &Object) -> Result<()> {
+        for v in &object.vertices {
+            self.serialize_vertex(v, "v")?;
+        }
+        for uv in &object.tex_vertices {
+            self.serialize_uv(uv)?;
+        }
+        for n in &object.normals {
+            self.serialize_vertex(n, "vn")?
+        }
+        Ok(())
     }
 
-    fn serialize_uv(uv: &TVertex) -> String {
+    fn serialize_geometry(&mut self, geometry: &Geometry) -> Result<()> {
+        for s in &geometry.shapes {
+            self.serialize_shape(s)?;
+        }
+        Ok(())
+    }
+
+    fn serialize_vertex(&mut self, v: &Vertex, prefix: &str) -> Result<()> {
+        write!(self.output, "{} {:.6} {:.6} {:.6}\n", prefix, v.x, v.y, v.z)
+    }
+
+    fn serialize_uv(&mut self, uv: &TVertex) -> Result<()> {
         if uv.w == 0.0 {
-            format!("vt {:.6} {:.6}\n", uv.u, uv.v)
+            write!(self.output, "vt {:.6} {:.6}\n", uv.u, uv.v)
         } else {
-            format!("vt {:.6} {:.6} {:.6}\n", uv.u, uv.v, uv.w)
+            write!(self.output, "vt {:.6} {:.6} {:.6}\n", uv.u, uv.v, uv.w)
         }
     }
 
-    fn serialize_shape(&self, shape: &Shape) -> String {
+    fn serialize_shape(&mut self, shape: &Shape) -> Result<()> {
         match shape.primitive {
-            Primitive::Point(vtn) => format!("p {}\n", self.serialize_vtn(vtn)),
-            Primitive::Line(vtn1, vtn2) => format!("l {} {}\n", self.serialize_vtn(vtn1), self.serialize_vtn(vtn2)),
-            Primitive::Triangle(vtn1, vtn2, vtn3) => format!("f {} {} {}\n", self.serialize_vtn(vtn1), self.serialize_vtn(vtn2), self.serialize_vtn(vtn3)),
+            Primitive::Point(vtn) => {
+                write!(self.output, "p")?;
+                self.serialize_vtn(vtn)?;
+            }
+            Primitive::Line(vtn1, vtn2) => {
+                write!(self.output, "l")?;
+                self.serialize_vtn(vtn1)?;
+                self.serialize_vtn(vtn2)?;
+            }
+            Primitive::Triangle(vtn1, vtn2, vtn3) => {
+                write!(self.output, "f")?;
+                self.serialize_vtn(vtn1)?;
+                self.serialize_vtn(vtn2)?;
+                self.serialize_vtn(vtn3)?;
+            }
         }
+        writeln!(self.output, "")
     }
 
-    fn serialize_vtn(&self, vtn: VTNIndex) -> String {
+    fn serialize_vtn(&mut self, vtn: VTNIndex) -> Result<()> {
         match vtn {
-            (vi, None, None) => format!("{}", vi + self.v_base_id),
-            (vi, Some(ti), None) => format!("{}/{}", vi + self.v_base_id, ti + self.uv_base_id),
-            (vi, Some(ti), Some(ni)) => format!("{}/{}/{}", vi + self.v_base_id, ti + self.uv_base_id, ni + self.n_base_id),
-            (vi, None, Some(ni)) => format!("{}//{}", vi + self.v_base_id, ni + self.n_base_id),
+            (vi, None, None) => write!(self.output, " {}", vi + self.v_base_id),
+            (vi, Some(ti), None) => write!(
+                self.output,
+                " {}/{}",
+                vi + self.v_base_id,
+                ti + self.uv_base_id
+            ),
+            (vi, Some(ti), Some(ni)) => write!(
+                self.output,
+                " {}/{}/{}",
+                vi + self.v_base_id,
+                ti + self.uv_base_id,
+                ni + self.n_base_id
+            ),
+            (vi, None, Some(ni)) => write!(
+                self.output,
+                " {}//{}",
+                vi + self.v_base_id,
+                ni + self.n_base_id
+            ),
         }
     }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,52 +1,42 @@
 extern crate obj_exporter as obj;
 
-use obj::{ObjSet, Object, Vertex, TVertex, Geometry, Shape, Primitive};
+use obj::{Geometry, ObjSet, Object, Primitive, Shape, TVertex, Vertex};
 
 #[test]
 pub fn test_square() {
-    let set = ObjSet {
-      material_library: None,
-      objects: vec![
-        Object {
-          name: "Square".to_owned(),
-          vertices: vec![
-            (-1, -1, 0),
-            (1, -1, 0),
-            (1, 1, 0),
-            (-1, 1, 0)
-          ].into_iter().map(|(x, y, z)| {
-            Vertex {
-              x: x as f64,
-              y: y as f64,
-              z: z as f64,
-            }
-          }).collect(),
-          tex_vertices: vec![],
-          normals: vec![],
-          geometry: vec![
-            Geometry {
-              material_name: None,
-              shapes: vec![
-                (0, 1, 2),
-                (0, 2, 3)
-              ].into_iter().map(|(x, y, z)| {
-                Shape {
-                  primitive: Primitive::Triangle(
-                    (x, None, None),
-                    (y, None, None),
-                    (z, None, None)
-                  ),
-                  groups: vec![],
-                  smoothing_groups: vec![],
-                }
-              }).collect(),
-            }
-          ],
-        }
-      ],
-    };
+  let set = ObjSet {
+    material_library: None,
+    objects: vec![
+      Object {
+        name: "Square".to_owned(),
+        vertices: vec![
+          (-1.0, -1.0, 0.0),
+          (1.0, -1.0, 0.0),
+          (1.0, 1.0, 0.0),
+          (-1.0, 1.0, 0.0),
+        ].into_iter()
+          .map(|(x, y, z)| Vertex { x, y, z })
+          .collect(),
+        tex_vertices: vec![],
+        normals: vec![],
+        geometry: vec![
+          Geometry {
+            material_name: None,
+            shapes: vec![(0, 1, 2), (0, 2, 3)]
+              .into_iter()
+              .map(|(x, y, z)| Shape {
+                primitive: Primitive::Triangle((x, None, None), (y, None, None), (z, None, None)),
+                groups: vec![],
+                smoothing_groups: vec![],
+              })
+              .collect(),
+          },
+        ],
+      },
+    ],
+  };
 
-    let expected = r#"o Square
+  let expected = r#"o Square
 v -1.000000 -1.000000 0.000000
 v 1.000000 -1.000000 0.000000
 v 1.000000 1.000000 0.000000
@@ -54,69 +44,53 @@ v -1.000000 1.000000 0.000000
 f 1 2 3
 f 1 3 4
 "#;
-
-    let result = obj::export(&set);
-    assert_eq!(result, expected);
+  let mut output = Vec::<u8>::new();
+  obj::export(&set, &mut output).unwrap();
+  assert_eq!(String::from_utf8(output).unwrap(), expected);
 }
 
 #[test]
 pub fn test_square_with_uv() {
-    let set = ObjSet {
-        material_library: None,
-        objects: vec![
-        Object {
-          name: "Square".to_owned(),
-          vertices:
-            vec![(-1, -1,  0),
-                 (1, -1, 0),
-                 (1, 1, 0),
-                 (-1, 1,  0)]
-            .into_iter()
-            .map(|(x, y, z)|
-              Vertex {
-                x: x as f64,
-                y: y as f64,
-                z: z as f64
+  let set = ObjSet {
+    material_library: None,
+    objects: vec![
+      Object {
+        name: "Square".to_owned(),
+        vertices: vec![
+          (-1.0, -1.0, 0.0),
+          (1.0, -1.0, 0.0),
+          (1.0, 1.0, 0.0),
+          (-1.0, 1.0, 0.0),
+        ].into_iter()
+          .map(|(x, y, z)| Vertex { x, y, z })
+          .collect(),
+        tex_vertices: vec![(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0)]
+          .into_iter()
+          .map(|(u, v)| TVertex { u, v, w: 0.0 })
+          .collect(),
+        normals: vec![],
+        geometry: vec![
+          Geometry {
+            material_name: None,
+            shapes: vec![(0, 1, 2), (0, 2, 3)]
+              .into_iter()
+              .map(|(x, y, z)| Shape {
+                primitive: Primitive::Triangle(
+                  (x, Some(x), None),
+                  (y, Some(y), None),
+                  (z, Some(z), None),
+                ),
+                groups: vec![],
+                smoothing_groups: vec![],
               })
-            .collect(),
-          tex_vertices: vec![
-            (0, 0),
-            (1, 0),
-            (1, 1),
-            (0, 1),
-          ].into_iter().map(|(u, v)|
-            TVertex {
-              u: u as f64,
-              v: v as f64,
-              w: 0.0,
-            }
-          ).collect(),
-          normals: vec!(),
-          geometry: vec!(
-            Geometry {
-              material_name: None,
-              shapes:
-                vec![(0, 1, 2),
-                     (0, 2, 3)]
-                .into_iter()
-                .map(|(x, y, z)|
-                  Shape {
-                    primitive:
-                      Primitive::Triangle(
-                        (x, Some(x), None),
-                        (y, Some(y), None),
-                        (z, Some(z), None)),
-                    groups: vec!(),
-                    smoothing_groups: vec!(),
-                  })
-                .collect()
-            }
-          )
-        }
-      ],
-    };
+              .collect(),
+          },
+        ],
+      },
+    ],
+  };
 
-    let expected = r#"o Square
+  let expected = r#"o Square
 v -1.000000 -1.000000 0.000000
 v 1.000000 -1.000000 0.000000
 v 1.000000 1.000000 0.000000
@@ -129,74 +103,59 @@ f 1/1 2/2 3/3
 f 1/1 3/3 4/4
 "#;
 
-    let result = obj::export(&set);
-    assert_eq!(result, expected);
+  let mut output = Vec::<u8>::new();
+  obj::export(&set, &mut output).unwrap();
+  assert_eq!(String::from_utf8(output).unwrap(), expected);
 }
 
 #[test]
 pub fn test_square_with_uv_and_normals() {
-    let set = ObjSet {
-        material_library: None,
-        objects: vec![
-        Object {
-          name: "Square".to_owned(),
-          vertices:
-            vec![(-1, -1,  0),
-                 (1, -1, 0),
-                 (1, 1, 0),
-                 (-1, 1,  0)]
-            .into_iter()
-            .map(|(x, y, z)|
-              Vertex {
-                x: x as f64,
-                y: y as f64,
-                z: z as f64
+  let set = ObjSet {
+    material_library: None,
+    objects: vec![
+      Object {
+        name: "Square".to_owned(),
+        vertices: vec![
+          (-1.0, -1.0, 0.0),
+          (1.0, -1.0, 0.0),
+          (1.0, 1.0, 0.0),
+          (-1.0, 1.0, 0.0),
+        ].into_iter()
+          .map(|(x, y, z)| Vertex { x, y, z })
+          .collect(),
+        tex_vertices: vec![(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0)]
+          .into_iter()
+          .map(|(u, v)| TVertex { u, v, w: 0.0 })
+          .collect(),
+        normals: vec![
+          Vertex {
+            x: 0.0,
+            y: 0.0,
+            z: -1.0,
+          },
+        ],
+        geometry: vec![
+          Geometry {
+            material_name: None,
+            shapes: vec![(0, 1, 2), (0, 2, 3)]
+              .into_iter()
+              .map(|(x, y, z)| Shape {
+                primitive: Primitive::Triangle(
+                  (x, Some(x), Some(0)),
+                  (y, Some(y), Some(0)),
+                  (z, Some(z), Some(0)),
+                ),
+                groups: vec![],
+                smoothing_groups: vec![],
               })
-            .collect(),
-          tex_vertices: vec![
-            (0, 0),
-            (1, 0),
-            (1, 1),
-            (0, 1),
-          ].into_iter().map(|(u, v)|
-            TVertex {
-              u: u as f64,
-              v: v as f64,
-              w: 0.0,
-            }
-          ).collect(),
-          normals: vec![
-            Vertex {
-              x: 0.0,
-              y: 0.0,
-              z: -1.0,
-            }
-          ],
-          geometry: vec!(
-            Geometry {
-              material_name: None,
-              shapes:
-                vec![(0, 1, 2),
-                     (0, 2, 3)]
-                .into_iter()
-                .map(|(x, y, z)|
-                  Shape {
-                    primitive:
-                      Primitive::Triangle(
-                        (x, Some(x), Some(0)),
-                        (y, Some(y), Some(0)),
-                        (z, Some(z), Some(0))),
-                    groups: vec!(),
-                    smoothing_groups: vec!(),
-                  })
-                .collect()
-            }
-          )
-        }
-      ],
-    };
+              .collect(),
+          },
+        ],
+      },
+    ],
+  };
 
-    let expected = r#"o Square
+  let expected = r#"o Square
 v -1.000000 -1.000000 0.000000
 v 1.000000 -1.000000 0.000000
 v 1.000000 1.000000 0.000000
@@ -210,91 +169,72 @@ f 1/1/1 2/2/1 3/3/1
 f 1/1/1 3/3/1 4/4/1
 "#;
 
-    let result = obj::export(&set);
-    assert_eq!(result, expected);
+  let mut output = Vec::<u8>::new();
+  obj::export(&set, &mut output).unwrap();
+  assert_eq!(String::from_utf8(output).unwrap(), expected);
 }
 
 #[test]
 pub fn test_multiple_objects() {
-    let set = ObjSet {
-      material_library: None,
-      objects: vec![
-        Object {
-          name: "Square1".to_owned(),
-          vertices: vec![
-            (-1, -1, 0),
-            (1, -1, 0),
-            (1, 1, 0),
-            (-1, 1, 0)
-          ].into_iter().map(|(x, y, z)| {
-            Vertex {
-              x: x as f64,
-              y: y as f64,
-              z: z as f64,
-            }
-          }).collect(),
-          tex_vertices: vec![],
-          normals: vec![],
-          geometry: vec![
-            Geometry {
-              material_name: None,
-              shapes: vec![
-                (0, 1, 2),
-                (0, 2, 3)
-              ].into_iter().map(|(x, y, z)| {
-                Shape {
-                  primitive: Primitive::Triangle(
-                    (x, None, None),
-                    (y, None, None),
-                    (z, None, None)
-                  ),
-                  groups: vec![],
-                  smoothing_groups: vec![],
-                }
-              }).collect(),
-            }
-          ],
-        },
-        Object {
-          name: "Square2".to_owned(),
-          vertices: vec![
-            (1, -1, 0),
-            (2, -1, 0),
-            (2, 1, 0),
-            (1, 1, 0)
-          ].into_iter().map(|(x, y, z)| {
-            Vertex {
-              x: x as f64,
-              y: y as f64,
-              z: z as f64,
-            }
-          }).collect(),
-          tex_vertices: vec![],
-          normals: vec![],
-          geometry: vec![
-            Geometry {
-              material_name: None,
-              shapes: vec![
-                (0, 1, 2),
-                (0, 2, 3)
-              ].into_iter().map(|(x, y, z)| {
-                Shape {
-                  primitive: Primitive::Triangle(
-                    (x, None, None),
-                    (y, None, None),
-                    (z, None, None)
-                  ),
-                  groups: vec![],
-                  smoothing_groups: vec![],
-                }
-              }).collect(),
-            }
-          ],
-        }
-      ],
-    };
+  let set = ObjSet {
+    material_library: None,
+    objects: vec![
+      Object {
+        name: "Square1".to_owned(),
+        vertices: vec![
+          (-1.0, -1.0, 0.0),
+          (1.0, -1.0, 0.0),
+          (1.0, 1.0, 0.0),
+          (-1.0, 1.0, 0.0),
+        ].into_iter()
+          .map(|(x, y, z)| Vertex { x, y, z })
+          .collect(),
+        tex_vertices: vec![],
+        normals: vec![],
+        geometry: vec![
+          Geometry {
+            material_name: None,
+            shapes: vec![(0, 1, 2), (0, 2, 3)]
+              .into_iter()
+              .map(|(x, y, z)| Shape {
+                primitive: Primitive::Triangle((x, None, None), (y, None, None), (z, None, None)),
+                groups: vec![],
+                smoothing_groups: vec![],
+              })
+              .collect(),
+          },
+        ],
+      },
+      Object {
+        name: "Square2".to_owned(),
+        vertices: vec![
+          (1.0, -1.0, 0.0),
+          (2.0, -1.0, 0.0),
+          (2.0, 1.0, 0.0),
+          (1.0, 1.0, 0.0),
+        ].into_iter()
+          .map(|(x, y, z)| Vertex { x, y, z })
+          .collect(),
+        tex_vertices: vec![],
+        normals: vec![],
+        geometry: vec![
+          Geometry {
+            material_name: None,
+            shapes: vec![(0, 1, 2), (0, 2, 3)]
+              .into_iter()
+              .map(|(x, y, z)| Shape {
+                primitive: Primitive::Triangle((x, None, None), (y, None, None), (z, None, None)),
+                groups: vec![],
+                smoothing_groups: vec![],
+              })
+              .collect(),
+          },
+        ],
+      },
+    ],
+  };
 
-    let expected = r#"o Square1
+  let expected = r#"o Square1
 v -1.000000 -1.000000 0.000000
 v 1.000000 -1.000000 0.000000
 v 1.000000 1.000000 0.000000
@@ -310,6 +250,7 @@ f 5 6 7
 f 5 7 8
 "#;
 
-    let result = obj::export(&set);
-    assert_eq!(result, expected);
+  let mut output = Vec::<u8>::new();
+  obj::export(&set, &mut output).unwrap();
+  assert_eq!(String::from_utf8(output).unwrap(), expected);
 }


### PR DESCRIPTION
We can now export geometry groups and smoothing groups. Also, as a part of this PR, exporter was refactored for better performance (writing directly to `Write`).